### PR TITLE
Bump to 4.49.0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,11 @@ on:
       - 'master'
   push:
     branches:
+      - 'feature*'
+      - 'feature/*'
       - 'feature_*'
+      - 'hotfix*'
+      - 'hotfix/*'
       - 'master'
   schedule:
     - cron: '0 18 * * *'

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Available variables are listed below (located in `defaults/main.yml`):
 
 ```yaml
 inspec_app: inspec
-inspec_version: 4.46.13
+inspec_version: 4.49.0
 inspec_debian_os: "{{ ansible_distribution|lower }}"
 inspec_debian_os_version: "{{ ansible_distribution_major_version }}"
 inspec_debian_os_arch: amd64
@@ -40,7 +40,7 @@ inspec_el_rpm_key_state: present
 Variable                      | Description
 ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------
 inspec_app                    | Defines the app to install i.e. **inspec**
-inspec_version                | Defined to dynamically fetch the desired version to install. Defaults to: **4.46.13**
+inspec_version                | Defined to dynamically fetch the desired version to install. Defaults to: **4.49.0**
 inspec_debian_os              | Defined to collect the operating system name and store it's value in lowercase
 inspec_debian_os_version      | Gathers facts to collect OS Version.
 inspec_debian_os_arch         | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **amd64**

--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ For customizing behavior of role (i.e. specifying the desired **inspec** version
 
 ## Author Information
 
-This role was created by [Ali Muhammad](https://www.linkedin.com/in/ali-muhammad-759791130/).
+This role was created by [Ali Muhammad](https://www.alimuhammad.dev/).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for inspec
 
 inspec_app: inspec
-inspec_version: 4.46.13
+inspec_version: 4.49.0
 inspec_debian_os: "{{ ansible_distribution|lower }}"
 inspec_debian_os_version: "{{ ansible_distribution_major_version }}"
 inspec_debian_os_arch: amd64


### PR DESCRIPTION
- Bump to InSpec version 4.49.0
- Additional push branches included for github actions `build-and-test` workflow
- Update author site url