### PR TITLE
Bump to 4.50.3 and other role changes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -57,10 +57,10 @@ jobs:
       with:
         path: 'darkwizard242.inspec'
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10.0
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10.0
 
     - name: Update repo cache, install python3-setuptools and required pip modules
       run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
   code_quality:
 
     name: SonarCloud Code Quality Check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
 
@@ -44,7 +44,7 @@ jobs:
   build:
 
     name: Build & Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 6
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   release:
 
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
       with:
         path: 'darkwizard242.inspec'
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10.0
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10.0
 
     - name: Update repo cache, install python3-setuptools and required pip modules
       run: |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Available variables are listed below (located in `defaults/main.yml`):
 
 ```yaml
 inspec_app: inspec
-inspec_version: 4.49.0
+inspec_version: 4.50.3
 inspec_debian_os: "{{ ansible_distribution|lower }}"
 inspec_debian_os_version: "{{ ansible_distribution_major_version }}"
 inspec_debian_os_arch: amd64
@@ -40,7 +40,7 @@ inspec_el_rpm_key_state: present
 Variable                      | Description
 ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------
 inspec_app                    | Defines the app to install i.e. **inspec**
-inspec_version                | Defined to dynamically fetch the desired version to install. Defaults to: **4.49.0**
+inspec_version                | Defined to dynamically fetch the desired version to install. Defaults to: **4.50.3**
 inspec_debian_os              | Defined to collect the operating system name and store it's value in lowercase
 inspec_debian_os_version      | Gathers facts to collect OS Version.
 inspec_debian_os_arch         | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **amd64**

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # defaults file for inspec
 
 inspec_app: inspec
-inspec_version: 4.49.0
+inspec_version: 4.50.3
 inspec_debian_os: "{{ ansible_distribution|lower }}"
 inspec_debian_os_version: "{{ ansible_distribution_major_version }}"
 inspec_debian_os_arch: amd64

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,7 +9,7 @@ lint: |
     flake8
 platforms:
   - name: ${DISTRO:-ubuntu-18.04}
-    image: "darkwizard242/ansible:${DISTRO:-ubuntu-18.04}"
+    image: "darkwizard242/ansible:${DISTRO:-ubuntu-20.04}"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     pre_build_image: true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,7 @@ sonar.projectKey=ansible-role-inspec
 sonar.organization=tech-overlord-github
 sonar.projectName=ansible-role-inspec
 sonar.coverage.exclusions=**/**
+sonar.python.version=3
 #sonar.projectVersion=$TRAVIS_JOB_ID
 
 # =====================================================


### PR DESCRIPTION
- Bump `inpsec` to 4.50.3
- Set default image in molecule config to Ubuntu 20.04
- Set default github action runner to Ubuntu 20.04 for `build-and-test` & `release` workflow
- Bump python version to 3.10.0 in `build-and-test` & `release` github action workflow
- Define `sonar.python.version` in sonarcloud config